### PR TITLE
feat: change 'Manage Feeds' to 'Manage RSS-Feed' on main entry page

### DIFF
--- a/rss-reader/templates/main/index.html.twig
+++ b/rss-reader/templates/main/index.html.twig
@@ -22,9 +22,9 @@
             <div class="col-md-4">
                 <div class="card">
                     <div class="card-body">
-                        <h5 class="card-title">📡 Manage Feeds</h5>
+                        <h5 class="card-title">📡 Manage RSS-Feed</h5>
                         <p class="card-text">Add, organize, and manage your RSS subscriptions</p>
-                        <a href="{{ path('app_feeds_index') }}" class="btn btn-primary">Manage Feeds</a>
+                        <a href="{{ path('app_feeds_index') }}" class="btn btn-primary">Manage RSS-Feed</a>
                     </div>
                 </div>
             </div>


### PR DESCRIPTION
## Summary
- Updated the main entry page to change "Manage Feeds" to "Manage RSS-Feed" for better clarity
- Modified both the card title and button text in the template

## Test plan
- [ ] Verify the main entry page displays "Manage RSS-Feed" instead of "Manage Feeds"
- [ ] Confirm the functionality remains unchanged

🤖 Generated with [Claude Code](https://claude.ai/code)