### PR TITLE
feat: complete 'Manage Feeds' to 'Manage RSS-Feed' change in dashboard

### DIFF
--- a/rss-reader/templates/main/dashboard.html.twig
+++ b/rss-reader/templates/main/dashboard.html.twig
@@ -71,7 +71,7 @@
             </div>
             <div class="card-body">
                 <div class="d-grid gap-2">
-                    <a href="{{ path('app_feeds_index') }}" class="btn btn-primary">Manage Feeds</a>
+                    <a href="{{ path('app_feeds_index') }}" class="btn btn-primary">Manage RSS-Feed</a>
                     <button class="btn btn-outline-secondary">Mark All as Read</button>
                     <button class="btn btn-outline-secondary">Refresh All Feeds</button>
                 </div>


### PR DESCRIPTION
## Summary

This PR completes the branding update by changing the remaining "Manage Feeds" text to "Manage RSS-Feed" in the dashboard template, ensuring consistency across all user-facing templates.

### Changes
- Updated dashboard template (`templates/main/dashboard.html.twig`) to use "Manage RSS-Feed" instead of "Manage Feeds"
- Maintains consistency with the main entry page changes from the previous commit

### Testing
- The change is a simple text update that maintains the same functionality
- Verified that the button text now matches the branding used throughout the application

🤖 Generated with [Claude Code](https://claude.ai/code)