### PR TITLE
feat: add concurrency groups to Claude workflows

### DIFF
--- a/.github/workflows/claude-apply-feedback.yml
+++ b/.github/workflows/claude-apply-feedback.yml
@@ -7,6 +7,10 @@ on:
   issue_comment:
     types: [created]
 
+concurrency:
+  group: claude-apply-feedback-${{ github.event.pull_request.number || github.event.issue.number }}
+  cancel-in-progress: false
+
 jobs:
   apply-feedback:
     if: github.event.pull_request || (github.event.issue.pull_request && github.event.comment)

--- a/.github/workflows/claude-detail.yml
+++ b/.github/workflows/claude-detail.yml
@@ -10,6 +10,10 @@ on:
         required: true
         type: string
 
+concurrency:
+  group: claude-detail-${{ github.event.issue.number || github.event.inputs.issue_number }}
+  cancel-in-progress: true
+
 jobs:
   generate-detail:
     # Run on new issues OR when AI label is present but Story Ready is not

--- a/.github/workflows/claude-review.yml
+++ b/.github/workflows/claude-review.yml
@@ -11,6 +11,10 @@ on:
         required: false
         type: string
 
+concurrency:
+  group: claude-review-${{ github.event.pull_request.number || github.event.inputs.pr_number }}
+  cancel-in-progress: true
+
 jobs:
   review-pr:
     if: github.event.action != 'labeled' || contains(github.event.label.name, 'AI')

--- a/.github/workflows/claude-write.yml
+++ b/.github/workflows/claude-write.yml
@@ -5,6 +5,10 @@ on:
     types: [labeled]
     # run only when specific label is added
 
+concurrency:
+  group: claude-write-${{ github.event.issue.number }}
+  cancel-in-progress: true
+
 jobs:
   implement-story:
     if: contains(github.event.label.name, 'Story ready')


### PR DESCRIPTION
This PR adds concurrency groups to all Claude workflows to prevent duplicate runs:

- Add concurrency group to claude-review.yml to prevent duplicate PR review runs
- Add concurrency groups to claude-apply-feedback.yml, claude-detail.yml, and claude-write.yml

This ensures that only one instance of each workflow runs at a time, preventing resource conflicts and duplicate executions.

Cherry-picked commits:
- 22c4a52: feat: add concurrency group to prevent duplicate PR review runs  
- a4fb8d8: feat: add concurrency groups to all Claude workflows to prevent duplicate runs